### PR TITLE
fix: resolve lint errors and poetry CI failure

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -1,5 +1,4 @@
 import json
-from typing import Optional
 from uuid import uuid4
 
 from lnbits.db import Database, Filters, Page
@@ -101,7 +100,7 @@ async def create_scheduler_jobs(admin_id: str, data: CreateJobData) -> Job:
         raise ValueError(f"Failed to create scheduler job: {e!s}") from e
 
 
-async def get_scheduler_job(job_id: str) -> Optional[Job]:
+async def get_scheduler_job(job_id: str) -> Job | None:
     row = await db.fetchone(
         "SELECT * FROM scheduler.jobs WHERE id = :id",
         {"id": job_id},
@@ -178,7 +177,7 @@ async def delete_scheduler_jobs(job_id: str) -> None:
         raise ValueError(f"Failed to delete scheduler job: {e!s}") from e
 
 
-async def update_scheduler_job(job: Job) -> Optional[Job]:
+async def update_scheduler_job(job: Job) -> Job | None:
     try:
         if not job.url:
             raise ValueError("URL is required")
@@ -246,7 +245,7 @@ async def update_scheduler_job(job: Job) -> Optional[Job]:
         raise ValueError(f"Failed to update job: {e!s}") from e
 
 
-async def pause_scheduler(job_id: str, active: Optional[bool] = None) -> Optional[Job]:
+async def pause_scheduler(job_id: str, active: bool | None = None) -> Job | None:
     """Update a job status and keep APScheduler runtime in sync with DB."""
     job = await get_scheduler_job(job_id)
     if not job:

--- a/migrations.py
+++ b/migrations.py
@@ -3,8 +3,7 @@ async def m001_initial(db):
     """
     Initial jobs table.
     """
-    await db.execute(
-        """
+    await db.execute("""
         CREATE TABLE scheduler.jobs (
             id TEXT PRIMARY KEY,
             name TEXT NOT NULL,
@@ -12,19 +11,16 @@ async def m001_initial(db):
             command TEXT,
             schedule TEXT
         );
-    """
-    )
+    """)
 
 
 async def m002_add_jobs_attrs_column(db):
     """
     Initial jobs table.
     """
-    await db.execute(
-        """
+    await db.execute("""
         ALTER TABLE scheduler.jobs ADD COLUMN extra JSON
-    """
-    )
+    """)
 
 
 async def m003_update_columns_for_api(db):
@@ -43,21 +39,17 @@ async def m004_add_logging_db(db):
     """
     Add table for API call results
     """
-    await db.execute(
-        """
+    await db.execute("""
          CREATE TABLE scheduler.logs (
             id TEXT PRIMARY KEY,
             status TEXT NOT NULL,
             response TEXT NOT NULL,
             timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
         )
-        """
-    )
+        """)
 
 
 async def m005_add_job_id_to_log_entry(db):
-    await db.execute(
-        """
+    await db.execute("""
         ALTER TABLE scheduler.logs ADD COLUMN job_id TEXT
-        """
-    )
+        """)

--- a/models.py
+++ b/models.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-from typing import Optional
 
 from fastapi import Query
 from lnbits.db import FilterModel
@@ -15,17 +14,17 @@ class HeaderItems(BaseModel):
 
 
 class CreateJobData(BaseModel):
-    name: Optional[str] = Query(default=None, description="Name of the Job")
+    name: str | None = Query(default=None, description="Name of the Job")
     status: bool = Query(False)  # true is active, false if paused
-    selectedverb: Optional[str] = Query(default=None)
-    url: Optional[str] = Query(default=None)
-    headers: Optional[list[HeaderItems]]
-    body: Optional[str] = Query(default=None)
+    selectedverb: str | None = Query(default=None)
+    url: str | None = Query(default=None)
+    headers: list[HeaderItems] | None
+    body: str | None = Query(default=None)
     schedule: str = Field(
         ...,
         description="Cron schedule expression (e.g. '*/5 * * * *' for every 5 minutes)",
     )
-    extra: Optional[dict[str, str]] = Query(default=None)
+    extra: dict[str, str] | None = Query(default=None)
 
     @validator("schedule")
     def validate_schedule(cls, v):
@@ -41,14 +40,14 @@ class CreateJobData(BaseModel):
 
 class UpdateJobData(BaseModel):
     id: str
-    name: Optional[str] = Query(default=None, description="Name of the Job")
+    name: str | None = Query(default=None, description="Name of the Job")
     status: bool
-    selectedverb: Optional[str] = None
-    url: Optional[str] = None
-    headers: Optional[list[HeaderItems]]
-    body: Optional[str] = None
+    selectedverb: str | None = None
+    url: str | None = None
+    headers: list[HeaderItems] | None
+    body: str | None = None
     schedule: str = Query(default=None, description="Schedule to run")
-    extra: Optional[dict[str, str]] = Query(
+    extra: dict[str, str] | None = Query(
         default=None, description="Partial update for extra field"
     )
 
@@ -59,26 +58,26 @@ class Job(BaseModel):
     admin: str
     status: bool
     schedule: str
-    selectedverb: Optional[str] = None
-    url: Optional[str] = None
-    headers: Optional[list[HeaderItems]]
-    body: Optional[str] = None
-    extra: Optional[dict[str, str]]
+    selectedverb: str | None = None
+    url: str | None = None
+    headers: list[HeaderItems] | None
+    body: str | None = None
+    extra: dict[str, str] | None
 
 
 class JobFilters(FilterModel):
     id: str
     name: str
-    schedule: Optional[str] = None
-    selectedverb: Optional[str] = None
-    url: Optional[str] = None
-    body: Optional[str] = None
-    extra: Optional[dict[str, str]]
+    schedule: str | None = None
+    selectedverb: str | None = None
+    url: str | None = None
+    body: str | None = None
+    extra: dict[str, str] | None
 
 
 class LogEntry(BaseModel):
     id: str
     job_id: str
-    status: Optional[str] = None
-    response: Optional[str] = None
+    status: str | None = None
+    response: str | None = None
     timestamp: datetime = datetime.now(timezone.utc)

--- a/poetry.lock
+++ b/poetry.lock
@@ -670,7 +670,7 @@ version = "26.5.1"
 description = "The uncompromising code formatter."
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "black-26.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9942db8888e06943c5dde66ca0037dcff82a2a4ec1ad0ada9e0d2ee9d9823893"},
     {file = "black-26.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:89c93167a74d3a75dfaa38a5c7cca015537d5820dd7f17d63267d674a61cae90"},
@@ -867,7 +867,7 @@ version = "3.5.0"
 description = "Validate configuration and produce human readable error messages."
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0"},
     {file = "cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132"},
@@ -1813,7 +1813,7 @@ version = "2.6.19"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a"},
     {file = "identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842"},
@@ -1843,7 +1843,7 @@ version = "2.3.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
@@ -1901,7 +1901,7 @@ version = "0.15.0"
 description = "Mypyc runtime library"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "platform_python_implementation != \"PyPy\""
 files = [
     {file = "librt-0.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e1a49adf16a7c9d9646816c2946135527197b6fcf4347c7b8b761cf1bfbf4489"},
@@ -2492,7 +2492,7 @@ version = "1.20.2"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "mypy-1.20.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cf5a4db6dca263010e2c7bff081c89383c72d187ba2cf4c44759aac970e2f0c4"},
     {file = "mypy-1.20.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7b0e817b518bff7facd7f85ea05b643ad8bdcce684cf29784987b0a7c8e1f997"},
@@ -2561,7 +2561,7 @@ version = "1.1.0"
 description = "Type system extensions for programs checked with the mypy type checker."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
     {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
@@ -2573,7 +2573,7 @@ version = "1.10.0"
 description = "Node.js virtual environment builder"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827"},
     {file = "nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb"},
@@ -2637,7 +2637,7 @@ version = "1.1.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"},
     {file = "pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a"},
@@ -2771,7 +2771,7 @@ version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
@@ -2799,7 +2799,7 @@ version = "3.8.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pre_commit-3.8.0-py2.py3-none-any.whl", hash = "sha256:9a90a53bf82fdd8778d58085faf8d83df56e40dfe18f45b19446e26bf1b3a63f"},
     {file = "pre_commit-3.8.0.tar.gz", hash = "sha256:8bb6494d4a20423842e198980c9ecf9f96607a07ea29549e180eef9ae80fe7af"},
@@ -3320,7 +3320,7 @@ version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
     {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
@@ -3344,7 +3344,7 @@ version = "0.21.2"
 description = "Pytest support for asyncio"
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytest_asyncio-0.21.2-py3-none-any.whl", hash = "sha256:ab664c88bb7998f711d8039cacd4884da6430886ae8bbd4eded552ed2004f16b"},
     {file = "pytest_asyncio-0.21.2.tar.gz", hash = "sha256:d67738fc232b94b326b9d060750beb16e0074210b98dd8b58a5239fa2a154f45"},
@@ -3421,7 +3421,7 @@ version = "0.4.1"
 description = "A Fast, spec compliant Python 3.14+ tokenizer that runs on older Pythons."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5"},
     {file = "pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe"},
@@ -3498,7 +3498,7 @@ version = "6.0.3"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
     {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
@@ -3634,7 +3634,7 @@ version = "0.3.7"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "ruff-0.3.7-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:0e8377cccb2f07abd25e84fc5b2cbe48eeb0fea9f1719cad7caedb061d70e5ce"},
     {file = "ruff-0.3.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:15a4d1cc1e64e556fa0d67bfd388fed416b7f3b26d5d1c3e7d192c897e39ba4b"},
@@ -3912,7 +3912,7 @@ version = "2.4.1"
 description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "python_version == \"3.10\""
 files = [
     {file = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"},
@@ -4526,7 +4526,10 @@ idna = ">=2.0"
 multidict = ">=4.0"
 propcache = ">=0.2.1"
 
+[extras]
+dev = ["black", "mypy", "pre-commit", "pytest", "pytest-asyncio", "ruff"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "f9ea431101ebb0a990e3eb85c228779beb45804aef44159b260c34be57bb45dd"
+content-hash = "5724be63b73ecbf9de4a9d575d8d31e7f48de7415214eb4a9a5b70ac23ee66b2"

--- a/scheduler_handler.py
+++ b/scheduler_handler.py
@@ -1,7 +1,8 @@
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional
+from typing import TYPE_CHECKING, Any
 
 logger = logging.getLogger("scheduler")
 
@@ -21,8 +22,8 @@ if TYPE_CHECKING:
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 
-_scheduler: Optional[Any] = None
-_fallback_runner: Optional[asyncio.Task] = None
+_scheduler: Any | None = None
+_fallback_runner: asyncio.Task | None = None
 _fallback_jobs: dict[str, dict] = {}
 
 

--- a/views_api.py
+++ b/views_api.py
@@ -1,6 +1,5 @@
 import logging
 from http import HTTPStatus
-from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from lnbits.core.models import WalletTypeInfo
@@ -213,7 +212,7 @@ async def api_scheduler_jobs_create(
     response_model=Job,
     dependencies=[Depends(require_admin_key)],
 )
-async def api_scheduler_jobs_update(job_id: str, data: UpdateJobData) -> Optional[Job]:
+async def api_scheduler_jobs_update(job_id: str, data: UpdateJobData) -> Job | None:
     job = await get_scheduler_job(job_id)
     if not job:
         raise HTTPException(


### PR DESCRIPTION
## Summary
- Auto-fixes 37 ruff lint errors introduced by newer ruff version (pulled in by security dep update)
- Reformats `migrations.py` with black
- Adds `package-mode = false` to `[tool.poetry]` so `poetry install` CI check passes (this is an extension, not a standalone package)
- Updates `poetry.lock` to match pyproject.toml changes

#### Test plan
- [x] `uv run ruff check .` passes
- [x] `uv run black --check .` passes