### PR TITLE
fix: add package-mode = false for poetry CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ name = "lnbits-scheduler"
 version = "0.0.0"
 description = "LNbits, free and open-source Lightning wallet and accounts system."
 authors = ["Alan Bits <alan@lnbits.com>"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"


### PR DESCRIPTION
## Summary
- Adds `package-mode = false` to `[tool.poetry]` section
- Fixes the `poetry install` CI check that fails because this is an LNbits extension, not a standalone package

#### Test plan
- [x] poetry install should succeed with package-mode = false